### PR TITLE
XML Integration Test

### DIFF
--- a/commons-bio/src/main/kotlin/ebi/ac/uk/model/File.kt
+++ b/commons-bio/src/main/kotlin/ebi/ac/uk/model/File.kt
@@ -2,17 +2,17 @@ package ebi.ac.uk.model
 
 import java.util.Objects
 
-class File(var name: String, attributes: List<Attribute> = emptyList()) : Attributable(attributes) {
+class File(var path: String, attributes: List<Attribute> = emptyList()) : Attributable(attributes) {
 
     override fun equals(other: Any?): Boolean {
         if (other !is File) return false
         if (this === other) return true
 
-        return Objects.equals(this.name, other.name).and(
+        return Objects.equals(this.path, other.path).and(
                 Objects.equals(this.attributesMap, other.attributesMap))
     }
 
     override fun hashCode(): Int {
-        return Objects.hash(this.name, this.attributesMap)
+        return Objects.hash(this.path, this.attributesMap)
     }
 }

--- a/commons-bio/src/main/kotlin/ebi/ac/uk/model/TableModel.kt
+++ b/commons-bio/src/main/kotlin/ebi/ac/uk/model/TableModel.kt
@@ -87,7 +87,7 @@ class FilesTable(files: List<File> = emptyList()) : Table<File>(files) {
     override val header = TableFields.FILES_TABLE.toString()
 
     override fun toTableRow(t: File) = object : Row<File>(t) {
-        override val id = t.name
+        override val id = t.path
         override val attributes = t.attributes
     }
 }

--- a/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/SubmissionMapper.kt
+++ b/persistence/src/main/kotlin/ac/uk/ebi/biostd/persistence/mapping/SubmissionMapper.kt
@@ -83,7 +83,7 @@ class SubmissionMapper(private val tagsRepository: TagsDataRepository) {
         LinkDb(link.url, order, toAttributes(link.attributes, ::LinkAttribute), tableIndex)
 
     private fun toFile(file: File, order: Int, tableIndex: Int = NO_TABLE_INDEX) =
-        FileDb(file.name, order, toAttributes(file.attributes, ::FileAttribute), tableIndex)
+        FileDb(file.path, order, toAttributes(file.attributes, ::FileAttribute), tableIndex)
 
     private fun <F> toAttributes(attributes: List<Attribute>, build: (AttributeDb) -> F) =
         attributes.mapIndexedTo(sortedSetOf()) { index, order -> toAttribute(order, index, build) }

--- a/serialization/src/main/kotlin/ac/uk/ebi/biostd/json/deserialization/FileJsonDeserializer.kt
+++ b/serialization/src/main/kotlin/ac/uk/ebi/biostd/json/deserialization/FileJsonDeserializer.kt
@@ -19,7 +19,7 @@ class FileJsonDeserializer : StdDeserializer<File>(File::class.java) {
         val node: JsonNode = mapper.readTree(jp)
 
         return File(
-            name = node.getNode<TextNode>(FileFields.PATH.value).textValue(),
+            path = node.getNode<TextNode>(FileFields.PATH.value).textValue(),
             attributes = mapper.convertList(node.findNode<JsonNode>(FileFields.ATTRIBUTES.value)))
     }
 }

--- a/serialization/src/main/kotlin/ac/uk/ebi/biostd/json/serialization/FileJsonSerializer.kt
+++ b/serialization/src/main/kotlin/ac/uk/ebi/biostd/json/serialization/FileJsonSerializer.kt
@@ -11,12 +11,12 @@ import ebi.ac.uk.model.constants.FileFields
 
 class FileJsonSerializer : StdSerializer<File>(File::class.java) {
 
-    override fun isEmpty(provider: SerializerProvider, value: File): Boolean = value.name.isEmpty()
+    override fun isEmpty(provider: SerializerProvider, value: File): Boolean = value.path.isEmpty()
 
     override fun serialize(file: File, gen: JsonGenerator, provider: SerializerProvider) {
 
         gen.writeObj {
-            writeJsonString(FileFields.PATH, file.name)
+            writeJsonString(FileFields.PATH, file.path)
             writeJsonArray(FileFields.ATTRIBUTES, file.attributes)
         }
     }

--- a/serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/serialization/BuilderSecExtensions.kt
+++ b/serialization/src/main/kotlin/ac/uk/ebi/biostd/tsv/serialization/BuilderSecExtensions.kt
@@ -18,7 +18,7 @@ fun TsvBuilder.addSecLink(link: Link) {
 }
 
 fun TsvBuilder.addSecFile(file: File) {
-    with(FILE_KEY, file.name)
+    with(FILE_KEY, file.path)
 }
 
 fun TsvBuilder.addAttributes(attributes: List<Attribute>) {

--- a/serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/deserializer/AttributeXmlDeserializer.kt
+++ b/serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/deserializer/AttributeXmlDeserializer.kt
@@ -19,7 +19,7 @@ class AttributeXmlDeserializer(private val detailDeserializer: DetailsXmlDeseria
         return Attribute(
             name = node.getNodeAttribute(NAME),
             value = node.getNodeAttribute(VALUE),
-            reference = node.findNodeAttribute(REFERENCE)?.asBoolean().orFalse(),
+            reference = node.findProperty(REFERENCE)?.asBoolean().orFalse(),
             nameAttrs = detailDeserializer.deserializeList(node.getSubNodes(NAME_ATTRIBUTES)).toMutableList(),
             valueAttrs = detailDeserializer.deserializeList(node.getSubNodes(VAL_ATTRIBUTES)).toMutableList())
     }

--- a/serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/deserializer/FileXmlDeserializer.kt
+++ b/serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/deserializer/FileXmlDeserializer.kt
@@ -11,7 +11,7 @@ class FileXmlDeserializer(private val attributeXmlDeserializer: AttributeXmlDese
     override fun deserialize(node: Node): File {
         return File(
             path = node.getNodeAttribute(FileFields.PATH),
-            attributes = attributeXmlDeserializer.deserializeList(node.getNode(FileFields.ATTRIBUTES))
+            attributes = attributeXmlDeserializer.deserializeList(node.findNode(FileFields.ATTRIBUTES))
         )
     }
 }

--- a/serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/deserializer/FileXmlDeserializer.kt
+++ b/serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/deserializer/FileXmlDeserializer.kt
@@ -10,7 +10,7 @@ class FileXmlDeserializer(private val attributeXmlDeserializer: AttributeXmlDese
 
     override fun deserialize(node: Node): File {
         return File(
-            name = node.getNodeAttribute(FileFields.NAME),
+            name = node.getNodeAttribute(FileFields.PATH),
             attributes = attributeXmlDeserializer.deserializeList(node.getNode(FileFields.ATTRIBUTES))
         )
     }

--- a/serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/deserializer/FileXmlDeserializer.kt
+++ b/serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/deserializer/FileXmlDeserializer.kt
@@ -10,7 +10,7 @@ class FileXmlDeserializer(private val attributeXmlDeserializer: AttributeXmlDese
 
     override fun deserialize(node: Node): File {
         return File(
-            name = node.getNodeAttribute(FileFields.PATH),
+            path = node.getNodeAttribute(FileFields.PATH),
             attributes = attributeXmlDeserializer.deserializeList(node.getNode(FileFields.ATTRIBUTES))
         )
     }

--- a/serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/deserializer/LinkXmlDeserializer.kt
+++ b/serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/deserializer/LinkXmlDeserializer.kt
@@ -11,7 +11,7 @@ class LinkXmlDeserializer(private val attributeXmlDeserializer: AttributeXmlDese
     override fun deserialize(node: Node): Link {
         return Link(
             url = node.getNodeAttribute(LinkFields.URL),
-            attributes = attributeXmlDeserializer.deserializeList(node.getNode(LinkFields.ATTRIBUTES))
+            attributes = attributeXmlDeserializer.deserializeList(node.findNode(LinkFields.ATTRIBUTES))
         )
     }
 }

--- a/serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/deserializer/NodeExtensions.kt
+++ b/serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/deserializer/NodeExtensions.kt
@@ -55,8 +55,7 @@ fun Node.toXmlString() =
         }
     }.toString()
 
-fun Node.getNodeAttribute(key: Any): String = getNode(key).textContent
-fun Node.findNodeAttribute(key: Any): String? = findNode(key)?.textContent
+fun Node.getNodeAttribute(key: Any): String = getNode(key).textContent.trim()
 
-fun Node.findProperty(key: Any): String? = attributes.getNamedItem(key.toString())?.textContent
-fun Node.getProperty(key: Any): String = attributes.getNamedItem(key.toString()).textContent
+fun Node.findProperty(key: Any): String? = attributes.getNamedItem(key.toString())?.textContent?.trim()
+fun Node.getProperty(key: Any): String = attributes.getNamedItem(key.toString()).textContent.trim()

--- a/serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/deserializer/SectionXmlDeserializer.kt
+++ b/serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/deserializer/SectionXmlDeserializer.kt
@@ -23,6 +23,6 @@ class SectionXmlDeserializer(
             attributes = attributeXmlDeserializer.deserializeList(node.findNode(SectionFields.ATTRIBUTES)),
             links = linkXmlDeserializer.deserializeTableList(node.findNode(SectionFields.LINKS), LinkFields.LINK.value, ::LinksTable),
             files = fileXmlDeserializer.deserializeTableList(node.findNode(SectionFields.FILES), FileFields.FILE.value, ::FilesTable),
-            sections = deserializeTableList(node.findNode(SectionFields.SUBSECTIONS), SectionFields.SUBSECTIONS.value, ::SectionsTable))
+            sections = deserializeTableList(node.findNode(SectionFields.SUBSECTIONS), SectionFields.SECTION.value, ::SectionsTable))
     }
 }

--- a/serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/serializer/FileSerializer.kt
+++ b/serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/serializer/FileSerializer.kt
@@ -14,7 +14,7 @@ class FileSerializer : XmlStdSerializer<File>(File::class.java) {
     override fun serializeXml(value: File, gen: ToXmlGenerator, provider: SerializerProvider) {
         with(gen) {
             writeXmlObj(FileFields.FILE, value) {
-                writeXmlField(FileFields.PATH, value.name)
+                writeXmlField(FileFields.PATH, value.path)
                 writeXmlCollection(FileFields.ATTRIBUTES, value.attributes)
             }
         }

--- a/serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/serializer/FileSerializer.kt
+++ b/serialization/src/main/kotlin/ac/uk/ebi/biostd/xml/serializer/FileSerializer.kt
@@ -14,7 +14,7 @@ class FileSerializer : XmlStdSerializer<File>(File::class.java) {
     override fun serializeXml(value: File, gen: ToXmlGenerator, provider: SerializerProvider) {
         with(gen) {
             writeXmlObj(FileFields.FILE, value) {
-                writeXmlField(FileFields.NAME, value.name)
+                writeXmlField(FileFields.PATH, value.name)
                 writeXmlCollection(FileFields.ATTRIBUTES, value.attributes)
             }
         }

--- a/serialization/src/test/kotlin/ac/uk/ebi/biostd/json/deserialization/FileDeserializerTest.kt
+++ b/serialization/src/test/kotlin/ac/uk/ebi/biostd/json/deserialization/FileDeserializerTest.kt
@@ -42,7 +42,7 @@ class FileDeserializerTest {
         }.toString()
 
         val file = testInstance.deserialize<File>(fileJson)
-        assertThat(file.name).isEqualTo("/path/file.txt")
+        assertThat(file.path).isEqualTo("/path/file.txt")
         assertThat(file.attributes).containsExactly(Attribute("attr name", "attr value"))
     }
 
@@ -53,7 +53,7 @@ class FileDeserializerTest {
         }.toString()
 
         val file = testInstance.deserialize<File>(fileJson)
-        assertThat(file.name).isEqualTo("/path/file.txt")
+        assertThat(file.path).isEqualTo("/path/file.txt")
         assertThat(file.attributes).isEmpty()
     }
 }

--- a/serialization/src/test/kotlin/ac/uk/ebi/biostd/json/deserialization/TableJsonDeserializerTest.kt
+++ b/serialization/src/test/kotlin/ac/uk/ebi/biostd/json/deserialization/TableJsonDeserializerTest.kt
@@ -85,8 +85,8 @@ class TableJsonDeserializerTest {
     @Test
     fun `deserialize table of files`() {
         val expectedTable = FilesTable(mutableListOf(
-            File(name = "file1", attributes = mutableListOf(testAttribute)),
-            File(name = "file2")))
+            File(path = "file1", attributes = mutableListOf(testAttribute)),
+            File(path = "file2")))
 
         val json = jsonArray({
             "path" to "file1"

--- a/serialization/src/test/kotlin/ac/uk/ebi/biostd/test/TestFactory.kt
+++ b/serialization/src/test/kotlin/ac/uk/ebi/biostd/test/TestFactory.kt
@@ -12,9 +12,9 @@ internal const val FILE_NAME = "file name"
 internal const val FILE_TYPE = "file type"
 internal const val FILE_SIZE = 55
 
-fun simpleFile() = File(name = FILE_NAME) // , type = FILE_TYPE, size = FILE_SIZE)
+fun simpleFile() = File(name = FILE_NAME)
 
 internal const val SEC_ACC_NO = "sec 123"
 internal const val SEC_TYPE = "sec type"
 
-fun simpleSection() = Section() // accNo = SEC_ACC_NO, type = SEC_TYPE)
+fun simpleSection() = Section(accNo = SEC_ACC_NO, type = SEC_TYPE)

--- a/serialization/src/test/kotlin/ac/uk/ebi/biostd/test/TestFactory.kt
+++ b/serialization/src/test/kotlin/ac/uk/ebi/biostd/test/TestFactory.kt
@@ -12,7 +12,7 @@ internal const val FILE_NAME = "file name"
 internal const val FILE_TYPE = "file type"
 internal const val FILE_SIZE = 55
 
-fun simpleFile() = File(name = FILE_NAME)
+fun simpleFile() = File(path = FILE_NAME)
 
 internal const val SEC_ACC_NO = "sec 123"
 internal const val SEC_TYPE = "sec type"

--- a/serialization/src/test/kotlin/ac/uk/ebi/biostd/tsv/TsvDeserializerTest.kt
+++ b/serialization/src/test/kotlin/ac/uk/ebi/biostd/tsv/TsvDeserializerTest.kt
@@ -219,7 +219,7 @@ class TsvDeserializerTest {
     }
 
     private fun assertFile(file: File, expectedName: String, vararg expectedAttributes: Attribute) {
-        assertThat(file.name).isEqualTo(expectedName)
+        assertThat(file.path).isEqualTo(expectedName)
         assertAttributes(file.attributes, expectedAttributes)
     }
 }

--- a/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/XmlSerializerITest.kt
+++ b/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/XmlSerializerITest.kt
@@ -5,16 +5,16 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class XmlSerializerITest {
-
     private val testInstance = XmlSerializer()
-
-    private val subm = createVenousBloodMonocyte()
+    private val submission = createVenousBloodMonocyte()
 
     @Test
     fun `serialize and deserialize sample submission`() {
-        val xml = testInstance.serialize(subm)
+        val xml = testInstance.serialize(submission)
         val result = testInstance.deserialize(xml)
 
-        assertThat(result).isEqualTo(subm)
+        assertThat(result.accNo).isEqualTo(submission.accNo)
+        assertThat(result.section).isEqualTo(submission.section)
+        assertThat(result.attributes).isEqualTo(submission.attributes)
     }
 }

--- a/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/common/XmlUtil.kt
+++ b/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/common/XmlUtil.kt
@@ -1,0 +1,11 @@
+package ac.uk.ebi.biostd.xml.common
+
+import org.xml.sax.InputSource
+import java.io.StringReader
+import javax.xml.parsers.DocumentBuilderFactory
+
+fun createXmlDocument(xml: String) =
+    DocumentBuilderFactory
+        .newInstance()
+        .newDocumentBuilder()
+        .parse(InputSource(StringReader(xml))).documentElement

--- a/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/deserializer/AttributeXmlDeserializerTest.kt
+++ b/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/deserializer/AttributeXmlDeserializerTest.kt
@@ -1,0 +1,49 @@
+package ac.uk.ebi.biostd.xml.deserializer
+
+import ac.uk.ebi.biostd.xml.common.createXmlDocument
+import ebi.ac.uk.model.Attribute
+import ebi.ac.uk.model.AttributeDetail
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.redundent.kotlin.xml.xml
+
+class AttributeXmlDeserializerTest {
+    private val testInstance = attributeXmlDeserializer()
+
+    @Test
+    fun `deserialize attribute`() {
+        val xmlAttribute = createXmlDocument(
+            xml("attribute") {
+                "name" { -"attr1" }
+                "value" { -"value1" }
+                "namequal" {
+                    "name" { -"nameDetail" }
+                    "value" { -"name detail 1" }
+                }
+                "valqual" {
+                    "name" { -"valDetail" }
+                    "value" { -"val detail 1" }
+                }
+            }.toString())
+
+        assertThat(testInstance.deserialize(xmlAttribute)).isEqualTo(
+            Attribute(
+                name = "attr1",
+                value = "value1",
+                reference = false,
+                nameAttrs = mutableListOf(AttributeDetail("nameDetail", "name detail 1")),
+                valueAttrs = mutableListOf(AttributeDetail("valDetail", "val detail 1"))))
+    }
+
+    @Test
+    fun `deserialize reference attribute`() {
+        val xmlAttribute = createXmlDocument(
+            xml("attribute") {
+                attribute("reference", true)
+                "name" { -"Organization" }
+                "value" { -"Org1" }
+            }.toString())
+
+        assertThat(testInstance.deserialize(xmlAttribute)).isEqualTo(Attribute("Organization", "Org1", true))
+    }
+}

--- a/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/deserializer/FileXmlDeserializerTest.kt
+++ b/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/deserializer/FileXmlDeserializerTest.kt
@@ -1,0 +1,39 @@
+package ac.uk.ebi.biostd.xml.deserializer
+
+import ac.uk.ebi.biostd.xml.common.createXmlDocument
+import ebi.ac.uk.model.Attribute
+import ebi.ac.uk.model.File
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.redundent.kotlin.xml.xml
+
+class FileXmlDeserializerTest {
+    private val testInstance = fileXmlDeserializer()
+
+    @Test
+    fun `deserialize file`() {
+        val xmlFile = createXmlDocument(
+            xml("file") {
+                "path" { -"file1.txt" }
+                "attributes" {
+                    "attribute" {
+                        "name" { -"attr1" }
+                        "value" { -"attr 1" }
+                    }
+                }
+            }.toString())
+
+        assertThat(testInstance.deserialize(xmlFile)).isEqualTo(
+            File("file1.txt", mutableListOf(Attribute("attr1", "attr 1"))))
+    }
+
+    @Test
+    fun `deserialize file without attributes`() {
+        val xmlFile = createXmlDocument(
+            xml("file") {
+                "path" { -"file1.txt" }
+            }.toString())
+
+        assertThat(testInstance.deserialize(xmlFile)).isEqualTo(File("file1.txt"))
+    }
+}

--- a/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/deserializer/LinkXmlDeserializerTest.kt
+++ b/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/deserializer/LinkXmlDeserializerTest.kt
@@ -1,0 +1,39 @@
+package ac.uk.ebi.biostd.xml.deserializer
+
+import ac.uk.ebi.biostd.xml.common.createXmlDocument
+import ebi.ac.uk.model.Attribute
+import ebi.ac.uk.model.Link
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.redundent.kotlin.xml.xml
+
+class LinkXmlDeserializerTest {
+    private val testInstance = linkXmlDeserializer()
+
+    @Test
+    fun `deserialize link`() {
+        val xmlLink = createXmlDocument(
+            xml("file") {
+                "url" { -"http://arandomurl.org" }
+                "attributes" {
+                    "attribute" {
+                        "name" { -"attr1" }
+                        "value" { -"attr 1" }
+                    }
+                }
+            }.toString())
+
+        assertThat(testInstance.deserialize(xmlLink)).isEqualTo(
+            Link("http://arandomurl.org", mutableListOf(Attribute("attr1", "attr 1"))))
+    }
+
+    @Test
+    fun `deserialize link without attributes`() {
+        val xmlLink = createXmlDocument(
+            xml("file") {
+                "url" { -"http://arandomurl.org" }
+            }.toString())
+
+        assertThat(testInstance.deserialize(xmlLink)).isEqualTo(Link("http://arandomurl.org"))
+    }
+}

--- a/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/deserializer/SectionXmlDeserializerTest.kt
+++ b/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/deserializer/SectionXmlDeserializerTest.kt
@@ -1,0 +1,22 @@
+package ac.uk.ebi.biostd.xml.deserializer
+
+import ac.uk.ebi.biostd.xml.common.createXmlDocument
+import ebi.ac.uk.model.Section
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.redundent.kotlin.xml.xml
+
+class SectionXmlDeserializerTest {
+    private val testInstance = sectionXmlDeserializer()
+
+    @Test
+    fun `deserialize section`() {
+        val xmlSection = createXmlDocument(
+            xml("section") {
+                attribute("accNo", "SECT-123")
+                attribute("type", "Study")
+            }.toString())
+
+        assertThat(testInstance.deserialize(xmlSection)).isEqualTo(Section("Study", "SECT-123"))
+    }
+}

--- a/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/deserializer/SubmissionXmlDeserializerTest.kt
+++ b/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/deserializer/SubmissionXmlDeserializerTest.kt
@@ -1,0 +1,35 @@
+package ac.uk.ebi.biostd.xml.deserializer
+
+import ac.uk.ebi.biostd.xml.common.createXmlDocument
+import ebi.ac.uk.model.Attribute
+import ebi.ac.uk.model.Section
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.redundent.kotlin.xml.xml
+
+class SubmissionXmlDeserializerTest {
+    private val testInstance = submissionXmlDeserializer()
+
+    @Test
+    fun `deserialize section`() {
+        val xmlSubmission = createXmlDocument(
+            xml("submission") {
+                attribute("accNo", "ABC123")
+                "attributes" {
+                    "attribute" {
+                        "name" { -"attr1" }
+                        "value" { -"attr 1" }
+                    }
+                }
+                "section" {
+                    attribute("accNo", "SECT-123")
+                    attribute("type", "Study")
+                }
+            }.toString())
+
+        val submission = testInstance.deserialize(xmlSubmission)
+        assertThat(submission.accNo).isEqualTo("ABC123")
+        assertThat(submission.section).isEqualTo(Section("Study", "SECT-123"))
+        assertThat(submission.attributes.first()).isEqualTo(Attribute("attr1", "attr 1"))
+    }
+}

--- a/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/deserializer/TestDeserializerFactory.kt
+++ b/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/deserializer/TestDeserializerFactory.kt
@@ -1,0 +1,12 @@
+package ac.uk.ebi.biostd.xml.deserializer
+
+fun attributeXmlDeserializer() = AttributeXmlDeserializer(DetailsXmlDeserializer())
+
+fun fileXmlDeserializer() = FileXmlDeserializer(attributeXmlDeserializer())
+
+fun linkXmlDeserializer() = LinkXmlDeserializer(attributeXmlDeserializer())
+
+fun sectionXmlDeserializer() =
+    SectionXmlDeserializer(attributeXmlDeserializer(), linkXmlDeserializer(), fileXmlDeserializer())
+
+fun submissionXmlDeserializer() = SubmissionXmlDeserializer(attributeXmlDeserializer(), sectionXmlDeserializer())

--- a/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/serializer/FileSerializerTest.kt
+++ b/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/serializer/FileSerializerTest.kt
@@ -1,8 +1,6 @@
 package ac.uk.ebi.biostd.xml.serializer
 
 import ac.uk.ebi.biostd.test.FILE_NAME
-import ac.uk.ebi.biostd.test.FILE_SIZE
-import ac.uk.ebi.biostd.test.FILE_TYPE
 import ac.uk.ebi.biostd.test.simpleFile
 import com.fasterxml.jackson.dataformat.xml.JacksonXmlModule
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
@@ -12,18 +10,14 @@ import org.redundent.kotlin.xml.xml
 import org.xmlunit.assertj.XmlAssert.assertThat
 
 class FileSerializerTest {
-
-    private val xmlMapper = XmlMapper(JacksonXmlModule().apply { addSerializer(File::class.java, FileSerializer()) })
-
     private val file = simpleFile()
+    private val xmlMapper = XmlMapper(JacksonXmlModule().apply { addSerializer(File::class.java, FileSerializer()) })
 
     @Test
     fun serializeXml() {
         val result = xmlMapper.writeValueAsString(file)
         val expected = xml("file") {
-            "name" { -FILE_NAME }
-            "type" { -FILE_TYPE }
-            "size" { -FILE_SIZE.toString() }
+            "path" { -FILE_NAME }
         }.toString()
 
         assertThat(result).and(expected).ignoreWhitespace().areIdentical()

--- a/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/serializer/LinkSerializerTest.kt
+++ b/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/serializer/LinkSerializerTest.kt
@@ -10,10 +10,8 @@ import org.redundent.kotlin.xml.xml
 import org.xmlunit.assertj.XmlAssert.assertThat
 
 class LinkSerializerTest {
-
-    private val xmlMapper = XmlMapper(JacksonXmlModule().apply { addSerializer(Link::class.java, LinkSerializer()) })
-
     private val link = simpleLink()
+    private val xmlMapper = XmlMapper(JacksonXmlModule().apply { addSerializer(Link::class.java, LinkSerializer()) })
 
     @Test
     fun serializeXml() {

--- a/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/serializer/SectionSerializerTest.kt
+++ b/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/serializer/SectionSerializerTest.kt
@@ -43,7 +43,7 @@ class SectionSerializerTest {
             }
             "files" {
                 "file" {
-                    "name" { -FILE_NAME }
+                    "path" { -FILE_NAME }
                     "attributes" {
                         "attribute" {
                             "name" { -"type" }

--- a/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/serializer/TableSerializerTest.kt
+++ b/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/serializer/TableSerializerTest.kt
@@ -39,7 +39,7 @@ class TableSerializerTest {
         val result = xmlMapper.writeValueAsString(FilesTable(listOf(simpleFile())))
         val expected = xml("table") {
             "file" {
-                "name" { -FILE_NAME }
+                "path" { -FILE_NAME }
                 "attributes" {}
             }
         }.toString()

--- a/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/serializer/TableSerializerTest.kt
+++ b/serialization/src/test/kotlin/ac/uk/ebi/biostd/xml/serializer/TableSerializerTest.kt
@@ -1,8 +1,6 @@
 package ac.uk.ebi.biostd.xml.serializer
 
 import ac.uk.ebi.biostd.test.FILE_NAME
-import ac.uk.ebi.biostd.test.FILE_SIZE
-import ac.uk.ebi.biostd.test.FILE_TYPE
 import ac.uk.ebi.biostd.test.LINK_URL
 import ac.uk.ebi.biostd.test.SEC_ACC_NO
 import ac.uk.ebi.biostd.test.SEC_TYPE
@@ -42,8 +40,6 @@ class TableSerializerTest {
         val expected = xml("table") {
             "file" {
                 "name" { -FILE_NAME }
-                "size" { -FILE_SIZE.toString() }
-                "type" { -FILE_TYPE }
                 "attributes" {}
             }
         }.toString()
@@ -58,10 +54,10 @@ class TableSerializerTest {
             "section" {
                 "type" { -SEC_TYPE }
                 "accNo" { -SEC_ACC_NO }
-                "attributes" {}
-                "subsections" {}
-                "links" {}
+                "sections" {}
                 "files" {}
+                "links" {}
+                "attributes" {}
             }
         }.toString()
 

--- a/submission-webapp/build.gradle
+++ b/submission-webapp/build.gradle
@@ -36,8 +36,9 @@ dependencies {
     testCompile("org.junit.jupiter:junit-jupiter-params:$junitVersion")
     testCompile("io.github.glytching:junit-extensions:2.3.0")
 
-    testCompile("org.springframework.boot:spring-boot-starter-test")
     testCompile("com.h2database:h2:1.4.197")
+    testCompile("org.redundent:kotlin-xml-builder:1.4.2")
+    testCompile("org.springframework.boot:spring-boot-starter-test")
 }
 
 sourceSets {

--- a/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/SubmissionTest.kt
+++ b/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/SubmissionTest.kt
@@ -8,6 +8,7 @@ import ac.uk.ebi.biostd.files.FileConfig
 import ac.uk.ebi.biostd.itest.common.setAppProperty
 import ac.uk.ebi.biostd.itest.factory.allInOneSubmissionJson
 import ac.uk.ebi.biostd.itest.factory.allInOneSubmissionTsv
+import ac.uk.ebi.biostd.itest.factory.allInOneSubmissionXml
 import ac.uk.ebi.biostd.itest.factory.invalidLinkUrl
 import ac.uk.ebi.biostd.itest.factory.simpleSubmissionTsv
 import ac.uk.ebi.biostd.persistence.service.ExtSubmissionRepository
@@ -66,7 +67,7 @@ class SubmissionTest(private val tempFolder: TemporaryFolder) {
     @ExtendWith(SpringExtension::class)
     @Import(value = [SubmitterConfig::class, PersistenceConfig::class, FileConfig::class])
     @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-    inner class SimpleSubmission {
+    inner class SingleSubmissionTest {
 
         @LocalServerPort
         private var serverPort: Int = 0
@@ -116,11 +117,19 @@ class SubmissionTest(private val tempFolder: TemporaryFolder) {
         }
 
         @Test
-        fun `submit all in one Json submission`() {
+        fun `submit all in one JSON submission`() {
             val response = webClient.submitSingle(allInOneSubmissionJson().toString(), SubmissionFormat.JSON)
             assertThat(response).isNotNull
             assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
             assertSavedSubmission("S-EPMC125")
+        }
+
+        @Test
+        fun `submit all in one XML submission`() {
+            val response = webClient.submitSingle(allInOneSubmissionXml().toString(), SubmissionFormat.XML)
+            assertThat(response).isNotNull
+            assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+            assertSavedSubmission("S-EPMC126")
         }
 
         @Test

--- a/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/SubmissionTest.kt
+++ b/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/SubmissionTest.kt
@@ -225,14 +225,14 @@ class SubmissionTest(private val tempFolder: TemporaryFolder) {
             assertThat(section.files).hasSize(2)
 
             val file = assertThat(section.files[0]).isFile()
-            assertThat(file.name).isEqualTo("LibraryFile1.txt")
+            assertThat(file.path).isEqualTo("LibraryFile1.txt")
             assertThat(file.attributes).containsExactly(Attribute("Description", "Library File 1"))
 
             val fileTable = assertThat(section.files[1]).isTable()
             assertThat(fileTable.elements).hasSize(1)
 
             val tableFile = fileTable.elements[0]
-            assertThat(tableFile.name).isEqualTo("LibraryFile2.txt")
+            assertThat(tableFile.path).isEqualTo("LibraryFile2.txt")
             assertThat(tableFile.attributes).hasSize(2)
             assertThat(tableFile.attributes[0]).isEqualTo(Attribute("Description", "Library File 2"))
             assertThat(tableFile.attributes[1]).isEqualTo(Attribute("Type", "Lib"))

--- a/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/factory/XmlSubmissionFactory.kt
+++ b/submission-webapp/src/itest/kotlin/ac/uk/ebi/biostd/itest/factory/XmlSubmissionFactory.kt
@@ -1,0 +1,117 @@
+package ac.uk.ebi.biostd.itest.factory
+
+import org.redundent.kotlin.xml.xml
+
+fun allInOneSubmissionXml() = xml("submission") {
+    attribute("accNo", "S-EPMC126")
+    "attributes" {
+        "attribute" {
+            "name" { -"Title" }
+            "value" { -"venous blood, Monocyte" }
+        }
+    }
+
+    "section" {
+        attribute("accNo", "SECT-001")
+        attribute("type", "Study")
+        "attributes" {
+            "attribute" {
+                "name" { -"Project" }
+                "value" { -"CEEHRC (McGill)" }
+            }
+            "attribute" {
+                attribute("reference", true)
+                "name" { -"Organization" }
+                "value" { -"Org1" }
+            }
+            "attribute" {
+                "name" { -"Tissue Type" }
+                "value" { -"venous blood" }
+                "valqual" {
+                    "name" { -"Ontology" }
+                    "value" { -"UBERON" }
+                }
+                "namequal" {
+                    "name" { -"Tissue" }
+                    "value" { -"Blood" }
+                }
+            }
+        }
+        "links" {
+            "link" {
+                "url" { -"AF069309" }
+                "attributes" {
+                    "attribute" {
+                        "name" { -"Type" }
+                        "value" { -"gen" }
+                    }
+                }
+            }
+        }
+        "files" {
+            "file" {
+                "path" { -"LibraryFile1.txt" }
+                "attributes" {
+                    "attribute" {
+                        "name" { -"Description" }
+                        "value" { -"Library File 1" }
+                    }
+                }
+            }
+            "table" {
+                "file" {
+                    "path" { -"LibraryFile2.txt" }
+                    "attributes" {
+                        "attribute" {
+                            "name" { -"Description" }
+                            "value" { -"Library File 2" }
+                        }
+                        "attribute" {
+                            "name" { -"Type" }
+                            "value" { -"Lib" }
+                        }
+                    }
+                }
+            }
+        }
+        "subsections" {
+            "section" {
+                attribute("accNo", "SUBSECT-001")
+                attribute("type", "Stranded Total RNA-Seq")
+                "links" {
+                    "table" {
+                        "link" {
+                            "url" { -"EGAD00001001282" }
+                            "attributes" {
+                                "attribute" {
+                                    "name" { -"Type" }
+                                    "value" { -"EGA" }
+                                }
+                                "attribute" {
+                                    "name" { -"Assay type" }
+                                    "value" { -"RNA-Seq" }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            "table" {
+                "section" {
+                    attribute("accNo", "DT-1")
+                    attribute("type", "Data")
+                    "attributes" {
+                        "attribute" {
+                            "name" { -"Title" }
+                            "value" { -"Group 1 Transcription Data" }
+                        }
+                        "attribute" {
+                            "name" { -"Description" }
+                            "value" { -"The data for zygotic transcription in mammals group 1" }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/FilesHandler.kt
+++ b/submitter/src/main/kotlin/ac/uk/ebi/biostd/submission/handlers/FilesHandler.kt
@@ -37,7 +37,7 @@ class FilesHandler(private val folderResolver: FolderResolver, private val seria
         val userPath = getUserFolder(submission)
 
         submission.allFiles()
-            .filter { file -> Files.exists(userPath.resolve(file.name)).not() }
+            .filter { file -> Files.exists(userPath.resolve(file.path)).not() }
             .ifNotEmpty { throw InvalidFilesException(it, INVALID_FILES_ERROR_MSG) }
     }
 
@@ -45,8 +45,8 @@ class FilesHandler(private val folderResolver: FolderResolver, private val seria
         val userPath = getUserFolder(submission)
 
         submission.allFiles().forEach { file ->
-            val sourceFile = userPath.resolve(file.name).toFile()
-            val submissionFile = folderResolver.getSubFilePath(submission.relPath, file.name).toFile()
+            val sourceFile = userPath.resolve(file.path).toFile()
+            val submissionFile = folderResolver.getSubFilePath(submission.relPath, file.path).toFile()
             FileUtils.copyFile(sourceFile, submissionFile)
         }
     }


### PR DESCRIPTION
- Create an integration test for XML
- Fix some properties that didn't correspond with the page tab standard
- Adjust unit tests accordingly
- Change File model to use "path" instead of "name" for the file path
- Add unit tests for XML deserializer